### PR TITLE
refactor: extract page-specific styles and clean up css

### DIFF
--- a/assets/css/guns-out.css
+++ b/assets/css/guns-out.css
@@ -1,0 +1,142 @@
+/* Styles für die Guns Out Seite */
+
+/* Screenshots/Slider */
+#screenshots .slider-container {
+    position: relative;
+    max-width: 100%;
+    margin: 0 auto;
+    overflow: hidden;
+}
+#screenshots .slider {
+    width: 100%;
+}
+#screenshots .slide {
+    display: none;
+}
+#screenshots .slide.active {
+    display: block;
+}
+#screenshots .slide img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 75vh; /* passt sich der Seite an, bleibt im Viewport */
+    object-fit: contain;
+    border-radius: 8px;
+}
+#screenshots .description {
+    font-size: 1.1rem;
+    color: #111111; /* fast schwarz */
+    margin-top: 8px;
+    text-align: center;
+}
+#screenshots .slider-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    border: none;
+    padding: 8px 12px;
+    cursor: pointer;
+    border-radius: 6px;
+    line-height: 1;
+    z-index: 2;
+    user-select: none;
+}
+#screenshots .slider-nav.prev { left: 8px; }
+#screenshots .slider-nav.next { right: 8px; }
+#screenshots .slider-nav:hover { background: rgba(0,0,0,0.65); }
+#screenshots .slider-nav:focus {
+    outline: 2px solid #8ab4f8;
+    outline-offset: 2px;
+}
+
+/* Hero mit geblurrtem Hintergrundbild statt Farbverlauf */
+.hero {
+    position: relative;
+    overflow: hidden;
+    background: none !important; /* überschreibt evtl. vorhandenen Verlauf */
+}
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('../img/img_level_1.png') center / cover no-repeat;
+    filter: blur(10px);
+    transform: scale(1.08); /* verhindert sichtbare Ränder durch den Blur */
+    z-index: 0;
+}
+.hero > .container {
+    position: relative;
+    z-index: 1;
+}
+
+/* Roadmap: Cards, zentriert unter der Überschrift, inhaltsbasiert breit */
+#roadmap .roadmap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+    align-items: flex-start;
+    width: fit-content;
+    max-width: 100%;
+    justify-content: center;
+}
+/* Roadmap Abschnitt: im normalen Inhaltsfluss, kein full-bleed Hintergrund */
+#roadmap {
+    margin-top: 32px;
+    padding: 0;
+    border: 0;
+    background: none;
+    position: relative;
+}
+
+/* Karten-Basisstil mit subtiler 2-Farben-Gradient-Füllung */
+#roadmap .roadmap li {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.10);
+    background:
+        linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
+        rgba(255, 255, 255, 0.82);
+    box-shadow: 0 1.5px 3px rgba(0,0,0,0.18);
+    flex: 0 0 auto; /* Breite durch Inhalt bestimmt */
+    max-width: 100%;
+    font-size: 1.1rem;
+    line-height: 1.25;
+    color: #0d0f14;
+}
+
+/* Milchglas für noch anstehende Punkte mit subtiler Verlaufstönung */
+#roadmap .roadmap li.pending {
+    background:
+        linear-gradient(135deg, rgba(124, 138, 100, 0.14), rgba(245, 205, 161, 0.14)),
+        rgba(255, 255, 255, 0.30);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    backdrop-filter: blur(10px) saturate(120%);
+    -webkit-backdrop-filter: blur(10px) saturate(120%);
+}
+#roadmap .roadmap li.pending:hover {
+    background:
+        linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
+        rgba(255, 255, 255, 0.36);
+}
+
+/* Zurück-Button */
+.back-home {
+    position: fixed;
+    top: 16px;
+    left: 16px;
+    z-index: 1000;
+}
+
+/* Step-Layout auf dieser Seite mittig ausrichten */
+.step {
+    align-items: center;
+}

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,0 +1,69 @@
+/* Styles spezifisch für die Startseite */
+
+/* Hintergrundbild für die Guns Out-Karte */
+.card--gunsout{
+    position: relative;
+    overflow: hidden;
+    background: none;
+    color: #fff;
+}
+.card--gunsout::before{
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('../img/img_level_1.png') center / cover no-repeat;
+    filter: blur(10px);
+    transform: scale(1.08); /* verhindert sichtbare Kanten durch den Blur */
+    z-index: 0;
+}
+.card--gunsout::after{
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0,0,0,.40), rgba(0,0,0,.20));
+    z-index: 1;
+}
+.card--gunsout > *{
+    position: relative;
+    z-index: 2;
+}
+
+/* Karten deutlich größer */
+.card-grid{
+    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+    gap: 24px;
+}
+.card{
+    padding: 28px 24px;
+    min-height: 240px;
+}
+
+/* Guns Out: Titel hervorheben */
+.card--gunsout h3{
+    color:#ffffff;
+}
+/* Guns Out: Beschreibungstext hell */
+.card--gunsout p{
+    color:rgba(255,255,255,.92);
+}
+
+/* Facts-Chips in der Karte im selben Stil wie auf der Projektseite */
+.card--gunsout .facts{
+    list-style:none;
+    padding:0;
+    margin:12px 0 0 0;
+    display:flex;
+    flex-wrap:wrap;
+    gap:10px 12px;
+}
+.card--gunsout .facts li{
+    padding:6px 12px;
+    border:1px solid var(--line);
+    border-radius:999px;
+    background:#f9fafb;
+    color:var(--text);
+    display:inline-flex;
+    align-items:center;
+    line-height:1;
+    font-weight:500;
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,7 +2,6 @@
     color-scheme: light;
 
     /* Basis-Palette – hell, neutral, mit zwei Akzenten */
-    --bg-0:#ffffff;
     --bg-1:#f8fafc;          /* sehr helles Grau fürs Seiten-Hintergrund */
     --panel:#ffffff;
     --line:#e5e7eb;          /* Haarlinie */
@@ -11,11 +10,8 @@
     --text:#0f172a;          /* Primärtext (nahe schwarz) */
     --muted:#64748b;         /* Sekundärtext */
     --accent:#2563eb;        /* Blau, primärer Akzent */
-    --accent-2:#f59e0b;      /* Orange, sekundärer Akzent */
 
     --radius-lg:16px;
-    --radius-md:12px;
-    --radius-sm:10px;
 
     --shadow-soft:0 1px 2px rgba(0,0,0,.05);
     --shadow-card:0 6px 22px rgba(15,23,42,.06);
@@ -255,28 +251,6 @@ section p{
 .video-embed.fullwidth iframe{ position:absolute; inset:0; width:100%; height:100%; }
 .item .video-embed{ aspect-ratio:16/9; width:100%; margin-left:0; }
 
-/* -------------------- Galerie -------------------- */
-.gallery{
-    display:grid;
-    grid-template-columns:repeat(auto-fit, minmax(260px,1fr));
-    gap:14px;
-}
-.shot{
-    background:var(--panel);
-    border:1px solid var(--line);
-    border-radius:14px;
-    padding:40px;
-    text-align:center;
-    color:var(--muted);
-    transition:transform .15s ease, box-shadow .15s ease, border-color .15s ease;
-    box-shadow:var(--shadow-card);
-}
-.shot:hover{
-    transform:translateY(-2px);
-    border-color:#d6dbe5;
-    box-shadow:0 16px 40px rgba(15,23,42,.10);
-}
-
 /* -------------------- Roadmap -------------------- */
 .roadmap{ list-style:none; padding:0; margin:0; display:grid; gap:8px; }
 .roadmap li{
@@ -361,7 +335,7 @@ footer{
 
 /* -------------------- Barrierearme Animation -------------------- */
 @media (prefers-reduced-motion:reduce){
-    .btn, .shot, .tech, .card{ transition:none; }
+    .btn, .tech, .card{ transition:none; }
 }
 
 /* -------------------- Dunkler, farbiger Hero (Seiten-spezifisch) -------------------- */

--- a/guns-out.html
+++ b/guns-out.html
@@ -7,142 +7,10 @@
     <meta name="color-scheme" content="dark">
     <meta name="theme-color" content="#0d0f14">
     <link rel="stylesheet" href="assets/css/style.css">
-    <style>
-        /* Screenshots/Slider */
-        #screenshots .slider-container {
-            position: relative;
-            max-width: 100%;
-            margin: 0 auto;
-            overflow: hidden;
-        }
-        #screenshots .slider {
-            width: 100%;
-        }
-        #screenshots .slide {
-            display: none;
-        }
-        #screenshots .slide.active {
-            display: block;
-        }
-        #screenshots .slide img {
-            display: block;
-            width: 100%;
-            height: auto;
-            max-height: 75vh; /* passt sich der Seite an, bleibt im Viewport */
-            object-fit: contain;
-            border-radius: 8px;
-        }
-        #screenshots .description {
-            font-size: 1.1rem;
-            color: #111111; /* fast schwarz */
-            margin-top: 8px;
-            text-align: center;
-        }
-        #screenshots .slider-nav {
-            position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
-            background: rgba(0, 0, 0, 0.5);
-            color: #fff;
-            border: none;
-            padding: 8px 12px;
-            cursor: pointer;
-            border-radius: 6px;
-            line-height: 1;
-            z-index: 2;
-            user-select: none;
-        }
-        #screenshots .slider-nav.prev { left: 8px; }
-        #screenshots .slider-nav.next { right: 8px; }
-        #screenshots .slider-nav:hover { background: rgba(0,0,0,0.65); }
-        #screenshots .slider-nav:focus {
-            outline: 2px solid #8ab4f8;
-            outline-offset: 2px;
-        }
-
-        /* Hero mit geblurrtem Hintergrundbild statt Farbverlauf */
-        .hero {
-            position: relative;
-            overflow: hidden;
-            background: none !important; /* überschreibt evtl. vorhandenen Verlauf */
-        }
-        .hero::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            background: url('assets/img/img_level_1.png') center / cover no-repeat;
-            filter: blur(10px);
-            transform: scale(1.08); /* verhindert sichtbare Ränder durch den Blur */
-            z-index: 0;
-        }
-        .hero > .container {
-            position: relative;
-            z-index: 1;
-        }
-
-        /* Roadmap: Cards, zentriert unter der Überschrift, inhaltsbasiert breit */
-        #roadmap .roadmap {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 12px 16px;
-            list-style: none;
-            padding: 0;
-            margin: 0 auto;
-            align-items: flex-start;
-            width: fit-content;
-            max-width: 100%;
-            justify-content: center;
-        }
-        /* Roadmap Abschnitt: im normalen Inhaltsfluss, kein full-bleed Hintergrund */
-        #roadmap {
-            margin-top: 32px;
-            padding: 0;
-            border: 0;
-            background: none;
-            position: relative;
-        }
-
-        /* (entfernt) Full-bleed-Hilfsregeln werden nicht mehr benötigt */
-
-        /* Titel und Beschreibung nutzen wieder die Standardfarben des Themes */
-
-        /* Karten-Basisstil mit subtiler 2-Farben-Gradient-Füllung */
-        #roadmap .roadmap li {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 12px 14px;
-            border-radius: 12px;
-            border: 1px solid rgba(0, 0, 0, 0.10);
-            background:
-                linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
-                rgba(255, 255, 255, 0.82);
-            box-shadow: 0 1.5px 3px rgba(0,0,0,0.18);
-            flex: 0 0 auto; /* Breite durch Inhalt bestimmt */
-            max-width: 100%;
-            font-size: 1.1rem;
-            line-height: 1.25;
-            color: #0d0f14;
-        }
-
-        /* Milchglas für noch anstehende Punkte mit subtiler Verlaufstönung */
-        #roadmap .roadmap li.pending {
-            background:
-                linear-gradient(135deg, rgba(124, 138, 100, 0.14), rgba(245, 205, 161, 0.14)),
-                rgba(255, 255, 255, 0.30);
-            border: 1px solid rgba(0, 0, 0, 0.15);
-            backdrop-filter: blur(10px) saturate(120%);
-            -webkit-backdrop-filter: blur(10px) saturate(120%);
-        }
-        #roadmap .roadmap li.pending:hover {
-            background:
-                linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
-                rgba(255, 255, 255, 0.36);
-        }
-    </style>
+    <link rel="stylesheet" href="assets/css/guns-out.css">
 </head>
 <body>
-<a href="index.html" class="btn back-home" aria-label="Zur Startseite" style="position: fixed; top: 16px; left: 16px; z-index: 1000;">← Zurück</a>
+<a href="index.html" class="btn back-home" aria-label="Zur Startseite">← Zurück</a>
 <!-- Hero -->
 <header class="hero hero--dark">
     <div class="container">
@@ -174,14 +42,14 @@
         </p>
         <p>Das Spiel läuft in Runden mit zwei Phasen:</p>
         <div class="steps">
-            <div class="step step--day" style="display: flex; align-items: center;">
+            <div class="step step--day">
                 <div class="icon"><img src="assets/icons/daycycle_indicator_day.png" alt="Tag"></div>
                 <div>
                     <h3>Tagsüber</h3>
                     <p>Items kaufen, Gadgets platzieren und NPCs beobachten, um echte Spieler zu enttarnen.</p>
                 </div>
             </div>
-            <div class="step step--night" style="display: flex; align-items: center;">
+            <div class="step step--night">
                 <div class="icon"><img src="assets/icons/daycycle_indicator_night.png" alt="Nacht"></div>
                 <div>
                     <h3>Nachts</h3>

--- a/index.html
+++ b/index.html
@@ -7,75 +7,7 @@
     <meta name="color-scheme" content="dark">
     <meta name="theme-color" content="#0d0f14">
     <link rel="stylesheet" href="assets/css/style.css">
-    <style>
-        /* Hintergrundbild für die Guns Out-Karte */
-        .card--gunsout{
-            position: relative;
-            overflow: hidden;
-            background: none;
-            color: #fff;
-        }
-        .card--gunsout::before{
-            content: "";
-            position: absolute;
-            inset: 0;
-            background: url('assets/img/img_level_1.png') center / cover no-repeat;
-            filter: blur(10px);
-            transform: scale(1.08); /* verhindert sichtbare Kanten durch den Blur */
-            z-index: 0;
-        }
-        .card--gunsout::after{
-            content: "";
-            position: absolute;
-            inset: 0;
-            background: linear-gradient(to top, rgba(0,0,0,.40), rgba(0,0,0,.20));
-            z-index: 1;
-        }
-        .card--gunsout > *{
-            position: relative;
-            z-index: 2;
-        }
-
-        /* Karten deutlich größer */
-        .card-grid{
-            grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
-            gap: 24px;
-        }
-        .card{
-            padding: 28px 24px;
-            min-height: 240px;
-        }
-
-        /* Guns Out: Titel hervorheben */
-        .card--gunsout h3{
-            color:#ffffff;
-        }
-        /* Guns Out: Beschreibungstext hell */
-        .card--gunsout p{
-            color:rgba(255,255,255,.92);
-        }
-
-        /* Facts-Chips in der Karte im selben Stil wie auf der Projektseite */
-        .card--gunsout .facts{
-            list-style:none;
-            padding:0;
-            margin:12px 0 0 0;
-            display:flex;
-            flex-wrap:wrap;
-            gap:10px 12px;
-        }
-        .card--gunsout .facts li{
-            padding:6px 12px;
-            border:1px solid var(--line);
-            border-radius:999px;
-            background:#f9fafb;
-            color:var(--text);
-            display:inline-flex;
-            align-items:center;
-            line-height:1;
-            font-weight:500;
-        }
-    </style>
+    <link rel="stylesheet" href="assets/css/index.css">
 </head>
 <body>
 <header class="hero">


### PR DESCRIPTION
## Summary
- move startpage-specific styling to dedicated `index.css`
- extract Guns Out page rules into `guns-out.css` and drop inline styles
- delete unused CSS variables and obsolete gallery/shot styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44bba31a8832b9061568dc7fa7f4f