### PR TITLE
style: adjust roadmap section styling

### DIFF
--- a/assets/css/guns-out.css
+++ b/assets/css/guns-out.css
@@ -88,24 +88,23 @@
 /* Roadmap Abschnitt: im normalen Inhaltsfluss, kein full-bleed Hintergrund */
 #roadmap {
     margin-top: 32px;
-    padding: 0;
-    border: 0;
+    padding: var(--space-lg) 0;
+    border-top: 1px solid var(--line);
+    margin-bottom: var(--space-lg);
     background: none;
     position: relative;
 }
 
-/* Karten-Basisstil mit subtiler 2-Farben-Gradient-Füllung */
+/* Karten-Basisstil ohne Farbakzent */
 #roadmap .roadmap li {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     padding: 12px 14px;
     border-radius: 12px;
-    border: 1px solid rgba(0, 0, 0, 0.10);
-    background:
-        linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
-        rgba(255, 255, 255, 0.82);
-    box-shadow: 0 1.5px 3px rgba(0,0,0,0.18);
+    border: 1px solid var(--line);
+    background: var(--panel);
+    box-shadow: var(--shadow-soft);
     flex: 0 0 auto; /* Breite durch Inhalt bestimmt */
     max-width: 100%;
     font-size: 1.1rem;
@@ -113,19 +112,15 @@
     color: #0d0f14;
 }
 
-/* Milchglas für noch anstehende Punkte mit subtiler Verlaufstönung */
+/* Schlichte Variante für noch anstehende Punkte */
 #roadmap .roadmap li.pending {
-    background:
-        linear-gradient(135deg, rgba(124, 138, 100, 0.14), rgba(245, 205, 161, 0.14)),
-        rgba(255, 255, 255, 0.30);
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    backdrop-filter: blur(10px) saturate(120%);
-    -webkit-backdrop-filter: blur(10px) saturate(120%);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
 }
 #roadmap .roadmap li.pending:hover {
-    background:
-        linear-gradient(135deg, rgba(124, 138, 100, 0.18), rgba(245, 205, 161, 0.18)),
-        rgba(255, 255, 255, 0.36);
+    background: var(--panel);
 }
 
 /* Zurück-Button */


### PR DESCRIPTION
## Summary
- add matching top divider and extra bottom spacing to roadmap section
- simplify roadmap card styling to remove colored gradients

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44d9eac10832ba733bfa67f373cd6