### PR TITLE
Style Doenertop screenshots

### DIFF
--- a/assets/css/doenertop.css
+++ b/assets/css/doenertop.css
@@ -8,20 +8,42 @@
     z-index: 1000;
 }
 
-/* Screenshots untereinander */
-#screenshots .screenshot {
+/* Screenshot-Features im Wechsel layouten */
+#screenshots .feature {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-md);
     margin-bottom: var(--space-lg);
     text-align: center;
 }
 
-#screenshots img {
-    width: 100%;
-    height: auto;
-    border-radius: 8px;
+#screenshots .phone-frame {
+    background: #000;
+    padding: 1rem;
+    border-radius: 32px;
     box-shadow: var(--shadow-soft);
+    flex-shrink: 0;
+}
+
+#screenshots .phone-frame img {
+    display: block;
+    height: 500px;
+    width: auto;
+    border-radius: 24px;
 }
 
 #screenshots p {
-    margin-top: var(--space-sm);
+    margin-top: 0;
     color: var(--muted);
+}
+
+@media (min-width: 768px) {
+    #screenshots .feature {
+        flex-direction: row;
+        text-align: left;
+    }
+    #screenshots .feature:nth-child(even) {
+        flex-direction: row-reverse;
+    }
 }

--- a/doenertop.html
+++ b/doenertop.html
@@ -36,16 +36,22 @@
     </section>
     <section id="screenshots">
         <h2>Funktionen</h2>
-        <div class="screenshot">
-            <img src="assets/img/doenertop/home_page_1.png" alt="Startseite mit Kartenansicht">
+        <div class="feature">
+            <div class="phone-frame">
+                <img src="assets/img/doenertop/home_page_1.png" alt="Startseite mit Kartenansicht">
+            </div>
             <p>Die Homepage zeigt eine Liste aller Dönerläden und einen Überblick über deren Angebot an</p>
         </div>
-        <div class="screenshot">
-            <img src="assets/img/doenertop/shop_page_1.png" alt="Detailansicht mit Bewertung">
+        <div class="feature">
+            <div class="phone-frame">
+                <img src="assets/img/doenertop/shop_page_1.png" alt="Detailansicht mit Bewertung">
+            </div>
             <p>Jeder Laden hat eine Detailseite mit dem genauen Angebot und den Community-Bewertungen</p>
         </div>
-        <div class="screenshot">
-            <img src="assets/img/doenertop/create_rating_1.png" alt="Ranking Liste">
+        <div class="feature">
+            <div class="phone-frame">
+                <img src="assets/img/doenertop/create_rating_1.png" alt="Ranking Liste">
+            </div>
             <p>Ein Laden lässt sich schnell und einfach über den "Bewertung erstellen" Dialog erstellen</p>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Resize DönerTop screenshots in a phone-like frame with rounded corners.
- Alternate screenshot and description alignment for better visual flow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b45975c570832b862ad5becfd24767