### PR TITLE
style: update font and text contrast on DönerTop page

### DIFF
--- a/assets/css/doenertop.css
+++ b/assets/css/doenertop.css
@@ -16,6 +16,13 @@
     background:#65977f;
     border-bottom:1px solid var(--line);
 }
+.hero h1{
+    font-family:'Delta Gothic One', sans-serif;
+    font-weight:700;
+}
+.hero .tagline{
+    color:var(--text);
+}
 
 /* Screenshot-Features im Wechsel layouten */
 #screenshots .feature {
@@ -44,7 +51,7 @@
 
 #screenshots p {
     margin-top: 0;
-    color: var(--muted);
+    color: var(--text);
 }
 
 @media (min-width: 768px) {

--- a/doenertop.html
+++ b/doenertop.html
@@ -8,6 +8,7 @@
     <meta name="color-scheme" content="dark">
     <meta name="theme-color" content="#0d0f14">
     <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Delta+Gothic+One&display=swap">
     <link rel="stylesheet" href="assets/css/doenertop.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- use Delta Gothic One font for DönerTop heading
- darken tagline and screenshot captions for improved contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b45d237408832ba6c08e24bf810bdf