### PR TITLE
Shrink hero and update tech stack

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,7 +72,7 @@ h3{
 .hero{
     position:relative;
     text-align:center;
-    padding:clamp(56px,8vw,var(--space-xl)) 0;
+    padding:clamp(40px,6vw,var(--space-lg)) 0;
     background:var(--panel);
     border-bottom:1px solid var(--line);
 }

--- a/assets/icons/csharp.svg
+++ b/assets/icons/csharp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="60" fill="#512BD4"/>
+  <text x="64" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="60" fill="white">C#</text>
+</svg>

--- a/assets/icons/java.svg
+++ b/assets/icons/java.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <path fill="#007396" d="M40 100h48c0 12-12 18-24 18s-24-6-24-18z"/>
+  <path fill="none" stroke="#007396" stroke-width="6" d="M32 64c24 12 40 12 64 0"/>
+  <path fill="none" stroke="#007396" stroke-width="6" d="M64 24c-8 8 8 12 8 20s-16 12-16 20"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -47,11 +47,11 @@
         <h2>Techstack</h2>
         <div class="tech-icons">
             <a class="tech" href="https://learn.microsoft.com/dotnet/csharp/" target="_blank" rel="noopener">
-                <img src="https://cdn.simpleicons.org/csharp/512BD4" alt="C#">
+                <img src="assets/icons/csharp.svg" alt="C#">
                 <span>C#</span>
             </a>
             <a class="tech" href="https://www.java.com/" target="_blank" rel="noopener">
-                <img src="https://cdn.simpleicons.org/java/007396" alt="Java">
+                <img src="assets/icons/java.svg" alt="Java">
                 <span>Java</span>
             </a>
             <a class="tech" href="https://dart.dev/" target="_blank" rel="noopener">
@@ -73,6 +73,14 @@
             <a class="tech" href="https://www.gimp.org/" target="_blank" rel="noopener">
                 <img src="https://cdn.simpleicons.org/gimp/5C5543" alt="Gimp">
                 <span>Gimp</span>
+            </a>
+            <a class="tech" href="https://git-scm.com/" target="_blank" rel="noopener">
+                <img src="https://cdn.simpleicons.org/git/F05032" alt="Git">
+                <span>Git</span>
+            </a>
+            <a class="tech" href="https://www.linux.org/" target="_blank" rel="noopener">
+                <img src="https://cdn.simpleicons.org/linux/FCC624" alt="Linux">
+                <span>Linux</span>
             </a>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- reduce hero section padding for a more compact top section
- add Git and Linux to the tech stack and switch Java/C# logos to local assets

## Testing
- `npx --yes prettier --check index.html assets/css/style.css`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68b463f9b7a4832b907e48d9b1c67ecb