### PR TITLE
Add tool logos to project cards

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -38,6 +38,7 @@
 .card{
     padding: 28px 24px;
     min-height: 240px;
+    position: relative;
 }
 
 /* Guns Out: Titel hervorheben */
@@ -100,4 +101,20 @@
     align-items:center;
     line-height:1;
     font-weight:500;
+}
+
+/* Tool-Logos in den Projektkarten */
+.tool-icons{
+    position:absolute;
+    top:12px;
+    right:12px;
+    display:flex;
+    gap:8px;
+    z-index:3;
+}
+
+.tool-icons img{
+    width:24px;
+    height:24px;
+    object-fit:contain;
 }

--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
         <h2>Aktive Projekte</h2>
         <div class="card-grid">
             <a class="card card--gunsout" href="guns-out.html">
+                <div class="tool-icons">
+                    <img src="assets/icons/c%23_icon.png" alt="C#">
+                    <img src="https://cdn.simpleicons.org/godotengine/478CBF" alt="Godot">
+                    <img src="https://cdn.simpleicons.org/blender/F5792A" alt="Blender">
+                </div>
                 <h3>Guns Out</h3>
                 <p>Ein Multiplayer Top-Down-Spiel mit Fokus auf Clean Code und Erweiterbarkeit.</p>
                 <ul class="facts">
@@ -32,6 +37,10 @@
             </a>
 
             <a class="card card--doenertop" href="doenertop.html">
+                <div class="tool-icons">
+                    <img src="https://cdn.simpleicons.org/dart/0175C2" alt="Dart">
+                    <img src="https://cdn.simpleicons.org/git/F05032" alt="Git">
+                </div>
                 <h3>DönerTop</h3>
                 <p>Eine App um schnell regionale Dönerläden zu bewerten.</p>
                 <ul class="facts">


### PR DESCRIPTION
## Summary
- show tool logos in Guns Out card (C#, Godot, Blender)
- display Dart and Git logos in DönerTop card
- style tool icon overlays in project cards

## Testing
- `npx prettier --check index.html assets/css/index.css` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4709a78b4832b9b50bd1eb596e43f